### PR TITLE
Introduce generic "federation" term instead of RFC 7523 specifics

### DIFF
--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -120,9 +120,9 @@ include databases, web servers, or other workloads. These resources are
 protected by an authorization server and require authentication via access
 token. The challenge for workloads is to obtain a token.
 
-The common use of the OAuth 2.0 framework {{RFC6749}} in this context poses 
+The common use of the OAuth 2.0 framework {{RFC6749}} in this context poses
 challenges, particularly in managing credentials. To address this, the industry
-has shifted to a federation-based approach where credentials of the underlying 
+has shifted to a federation-based approach where credentials of the underlying
 workload platform are used to authenticate to other identity providers, which in
  turn, issue credentials that grant access to resources.
 
@@ -135,7 +135,7 @@ materials can be stolen and used by attackers to impersonate the workload.
 
 Instead of provisioning secret material to the workload, one solution to this
 problem is to attest the workload by using its underlying platform. Many
-platforms provision workloads with a credential, such as a JWT token 
+platforms provision workloads with a credential, such as a JWT token
 ({{RFC7519}}). Cryptographically signed by the platform's authorization server,
 this credential attests the workload and its attributes.
 

--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -253,38 +253,10 @@ connections allow the issuer to push credentials.
 This pattern also requires client code, which introduces portability challenges.
 The request-response paradigm and additional operational overhead adds latency.
 
-# Usage patterns {#usage-pattern}
-
-Workloads can use the credential that was issued to them from the platform for
-many different purposes. For simplicity, we differentiate access of resources
-within and outside of the platform. A resource can also be a different workload,
-including invoking a remote procedure (HTTP POST, RPC, etc.).
-
-## Accessing other workloads within the platform
-
-Workloads often need to interact with the platform itself. For instance,
-storing or accessing data is a very common pattern and workload platform
-offer various features to facility this. Access is directly given by the
-credential issued from the platform.
-
-Also very common is the communication between workloads themselves. To secure
-access, they need to authenticate to another. The platform-issued credential often
-allows this out-of-the-box.
-
-> TODO: Talk about Bearer Tokens and audience?
-
-## Accessing resources outside of the platform
-
-Resources that don't reside within the platform can likely not accessed by the
-credential that was issued from the platform. This requires the workload to
-federate to an Identity Provider outside of the platform to receive access.
-This can for example be an OAuth 2.0 Authorization Server that issues Access Tokens
-but also other Identity systems that grant access.
-
 # Practices {#practices}
 
 The following practices outline more concrete examples of platforms, including their
-delivery and usage patterns.
+delivery patterns.
 
 ## Kubernetes {#kubernetes}
 
@@ -306,7 +278,7 @@ To programatically use service accounts, workloads can:
   referred to as "projected service account token".
 
 * Use the Token Request API {{TokenReviewV1}} of the control plane. This option,
-  however, requires an initial projected service account token as a mean of
+  however, requires an initial projected service account token as a means of
   authentication.
 
 Both options allow workloads to:
@@ -542,7 +514,7 @@ effectively an Identity Provider, to receive an identity of the other cloud.
 Using this different identity the workoad can then access its resources.
 
 This pattern also applies when accessing resources in the same cloud but across
-different security boundaries (different account /tenant). The actual flows and
+different security boundaries (e.g. different account or tenant). The actual flows and
 implementations may vary in these situations though.
 
 ~~~aasvg

--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -123,21 +123,21 @@ token. The challenge for workloads is to obtain a token.
 The common use of the OAuth 2.0 framework in this context poses challenges,
 particularly in managing credentials. To address this, the industry has shifted
 to a federation-based approach where credentials of the underlying workload
-platform are used to authenticate to other Identity Providers, which in turn, 
+platform are used to authenticate to other Identity Providers, which in turn,
 issue credentials that grant access to resources.
 
-Traditionally, workloads were provisioned with client credentials and use for 
-example the corresponding client credential flow (Section 1.3.4 {{RFC6749}}) to 
+Traditionally, workloads were provisioned with client credentials and use for
+example the corresponding client credential flow (Section 1.3.4 {{RFC6749}}) to
 retrieve an OAuth 2.0 access token. This model presents a number of security and
-maintenance issues. Secret materials must be provisioned and rotated, which 
-require either automation to be built, or periodic manual effort. Secret 
+maintenance issues. Secret materials must be provisioned and rotated, which
+require either automation to be built, or periodic manual effort. Secret
 materials can be stolen and used by attackers to impersonate the workload.
 
 Instead of provisioning secret material to the workload, one solution to this
 problem is to attest the workload by using its underlying platform. Many
 platforms provision workloads with a credential, such as a JWT token. Signed by
 a platform authorization server, this credential attests the workload and its
-attributes. 
+attributes.
 
 {{fig-overview}} illustrates a generic pattern that is seen across many workload
 platforms, more concrete variations are found in {{practices}}.
@@ -304,9 +304,9 @@ To programatically use service accounts, workloads can:
 * Have the token "projected" into the file system of the workload. This is
   similar to volume mounting in non-Kubernetes environments, and is commonly
   referred to as "projected service account token".
-  
+
 * Use the Token Request API {{TokenReviewV1}} of the control plane. This option,
-  however, requires an initial projected service account token as a mean of 
+  however, requires an initial projected service account token as a mean of
   authentication.
 
 Both options allow workloads to:
@@ -486,7 +486,7 @@ The steps shown in {{fig-spiffe}} are:
 
 * 1) The workload requests a JWT-SVID from the SPIFFE Workload API.
 
-* A) The JWT-SVID can be used to directly access resources or other workloads 
+* A) The JWT-SVID can be used to directly access resources or other workloads
      within the same SPIFFE Trust Domain.
 
 * B1) To access resource proctected by other Identity Providers the workload
@@ -495,7 +495,7 @@ The steps shown in {{fig-spiffe}} are:
 * B2) Once federated, the workload can access resources outside of its trust
       domain.
 
-> TODO: We should talk about native SPIFFE federation. Maybe a C) flow in the 
+> TODO: We should talk about native SPIFFE federation. Maybe a C) flow in the
 > diagram or at least some text.
 
 Here are example claims for a JWT-SVID:
@@ -536,13 +536,13 @@ from a user perspective, no credential needs to be issued, provisioned, rotated
 or revoked, as everything is handled internally by the platform.
 
 This is not true for resources outside of the platform, such as on-premise
-resources, generic web servers or other cloud provider resources. Here, the 
-workload firsts need to federate to the Secure Token Service (STS), which is 
-effectively an Identity Provider, to receive an identity of the other cloud. 
+resources, generic web servers or other cloud provider resources. Here, the
+workload firsts need to federate to the Secure Token Service (STS), which is
+effectively an Identity Provider, to receive an identity of the other cloud.
 Using this different identity the workoad can then access its resources.
 
 This pattern also applies when accessing resources in the same cloud but across
-different security boundaries (different account /tenant). The actual flows and 
+different security boundaries (different account /tenant). The actual flows and
 implementations may vary in these situations though.
 
 ~~~aasvg
@@ -606,7 +606,7 @@ a different authorization server).
 
 Continuous integration and deployment (CI-CD) systems allow their pipelines (or
 workflows) to receive an identity every time they run. Build outputs and other
-artifacts are commonly uploaded to external resources. With federation to 
+artifacts are commonly uploaded to external resources. With federation to
 external Identity Providers the pipelines and tasks can access these resources.
 
 ~~~aasvg
@@ -620,29 +620,29 @@ external Identity Providers the pipelines and tasks can access these resources.
     | |                 |             +------------+  |
     | +-----+-+---------+                             |
     +-------+-+---------------------------------------+
-            | |                                        
-            | |                     +--------------+   
-2) federate | | 3) access           |              |   
-            | +-------------------->|   Resource   |   
-            v                       |              |   
-      +-------------------+         +--------------+   
-      |                   |                            
-      | Identity Provider |                            
-      |                   |                            
-      +-------------------+                            
+            | |
+            | |                     +--------------+
+2) federate | | 3) access           |              |
+            | +-------------------->|   Resource   |
+            v                       |              |
+      +-------------------+         +--------------+
+      |                   |
+      | Identity Provider |
+      |                   |
+      +-------------------+
 ~~~
 {: #fig-cicd title="OAuth2 Assertion Flow in a continuous integration/deployment environment"}
 
 The steps shown in {{fig-cicd}} are:
 
-* 1) The CI-CD platform schedules a workload (pipeline or task). Based on 
+* 1) The CI-CD platform schedules a workload (pipeline or task). Based on
      configuration a Workload Identity is made available by the platform.
 
 * 2) The workload uses the identity to federate to a Identity Provider.
 
 * 3) The workload uses the federated identity to access resources. For instance,
-     a artifact store to upload compiled binaries, or to download libraries 
-     needed to resolve dependencies. It is also common to access other 
+     a artifact store to upload compiled binaries, or to download libraries
+     needed to resolve dependencies. It is also common to access other
      infrastructure as resources to make deployments or changes.
 
 Tokens of different providers look different, but all contain claims carrying
@@ -780,6 +780,10 @@ While {{RFC7521}} and {{RFC7523}} are the proposed standards for this pattern, s
 # Document History
 
    [[ To be removed from the final specification ]]
+
+   -latest
+
+   * Use more generic "federation" term instead of RFC 7523 specifics
 
    -02
 

--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -120,11 +120,11 @@ include databases, web servers, or other workloads. These resources are
 protected by an authorization server and require authentication via access
 token. The challenge for workloads is to obtain a token.
 
-The common use of the OAuth 2.0 framework in this context poses challenges,
-particularly in managing credentials. To address this, the industry has shifted
-to a federation-based approach where credentials of the underlying workload
-platform are used to authenticate to other Identity Providers, which in turn,
-issue credentials that grant access to resources.
+The common use of the OAuth 2.0 framework {{RFC6749}} in this context poses 
+challenges, particularly in managing credentials. To address this, the industry
+has shifted to a federation-based approach where credentials of the underlying 
+workload platform are used to authenticate to other identity providers, which in
+ turn, issue credentials that grant access to resources.
 
 Traditionally, workloads were provisioned with client credentials and use for
 example the corresponding client credential flow (Section 1.3.4 {{RFC6749}}) to
@@ -135,9 +135,9 @@ materials can be stolen and used by attackers to impersonate the workload.
 
 Instead of provisioning secret material to the workload, one solution to this
 problem is to attest the workload by using its underlying platform. Many
-platforms provision workloads with a credential, such as a JWT token. Signed by
-a platform authorization server, this credential attests the workload and its
-attributes.
+platforms provision workloads with a credential, such as a JWT token 
+({{RFC7519}}). Cryptographically signed by the platform's authorization server,
+this credential attests the workload and its attributes.
 
 {{fig-overview}} illustrates a generic pattern that is seen across many workload
 platforms, more concrete variations are found in {{practices}}.


### PR DESCRIPTION
The draft currently focuses heavily on RFC7523 (the JWT assertion framework). I don't think that's good because:

* RFC 7523 has 2 flows (client authentication and JWT authorization grants) leaving the reader guessing which one to use
* Limits this draft to only implementations of RFC 7523 (aka no AWS, no GCP)

Instead, this PR proposes to move towards the more generic term of "federation". This will include AWS, GCP and more and also will sound more familiar with readers that aren't as involved into specifics of OAuth such as the assertion framework. 

A new section called "usage patterns" aims to highlight various patterns workloads use their identity with, starting at accessing resources within the platform (no federation required) to federating to external Identity Providers and using a federated identity to access resources.