### PR TITLE
Rephrase invalidation

### DIFF
--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -685,7 +685,8 @@ domain, short-lived credentials are recommended.
 ## Workload lifecycle and invalidation
 
 Platform issuers SHOULD invalidate tokens when the workload stops, pauses, or
-ceases to exist. How these credentials are invalidated depends on platform
+ceases to exist and SHOULD offer validators the posibility to query this status.
+How these credentials are invalidated and the status is queried depends on platform
 authentication mechanisms and is not in scope of this document.
 
 ## Proof of possession


### PR DESCRIPTION
Rephrases invalidation to make it more clear that invalidation doesn't affect anything unless the validator queries the status.

Resolves #45