### PR TITLE
Reduced strings in JSON

### DIFF
--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -379,16 +379,26 @@ Account token.
 
 ~~~json
 {
-  "aud": [  # matches the requested audiences, or the API server's default audiences when none are explicitly requested
+  "aud": [
+    # matches the requested audiences, or the API server's
+    # default audiences when none are explicitly requested
     "https://kubernetes.default.svc"
   ],
   "exp": 1731613413,
   "iat": 1700077413,
-  "iss": "https://kubernetes.default.svc",  # matches the first value passed to the --service-account-issuer flag
-  "jti": "ea28ed49-2e11-4280-9ec5-bc3d1d84661a",  # ServiceAccountTokenJTI feature must be enabled for the claim to be present
+  "iss":
+    # matches the first value passed to the
+    # --service-account-issuer flag
+    "https://kubernetes.default.svc",
+  "jti":
+    # ServiceAccountTokenJTI feature must be enabled
+    # for the claim to be present
+    "ea28ed49-2e11-4280-9ec5-bc3d1d84661a",
   "kubernetes.io": {
     "namespace": "my-namespace",
-    "node": {  # ServiceAccountTokenPodNodeInfo feature must be enabled for the API server to add this node reference claim
+    "node": {
+      # ServiceAccountTokenPodNodeInfo feature must be enabled
+      # for the API server to add this node reference claim
       "name": "127.0.0.1",
       "uid": "58456cb0-dd00-45ed-b797-5578fdceaced"
     },


### PR DESCRIPTION
To address an issue raised by @jricher:

> Some of the diagrams and examples are too wide for ASCII rendering, investigate and fix these