### PR TITLE
Reworked intro to remove normative language

### DIFF
--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -710,23 +710,19 @@ All security considerations in section 8 of {{!OAUTH-ASSERTION=RFC7521}} apply.
 
 ### General Credentials Requirements {#general-requirements}
 
-Workload platforms and Identity Providers SHOULD issue credentials with as
-small a set of audiences as possible to limit the scope of any single
-credential. For JWT-based credentials, more specific requirements and security
-considerations for the `aud` claim are described in {{audience}}.
+Credentials SHOULD be scoped as narrowly as possible: each SHOULD carry the
+smallest set of audiences that lets it serve its purpose. A credential for direct access
+to a platform resource SHOULD be scoped to that resource; a credential used to
+federate to an Identity Provider SHOULD carry that Identity Provider as its sole audience.
+See {{audience}} for the rationale and for specific requirements on the `aud` claim of
+JWT-based credentials.
 
-Credentials used for direct access to platform resources SHOULD be scoped
-specifically to the platform resource being accessed.
-
-Credentials used to federate to an Identity Provider SHOULD carry that Identity
-Provider as their sole audience. A credential used for federation SHOULD NOT be
-the same credential used for direct platform access. Reusing a credential across
-platform access and federation contexts can conflate trust boundaries and
-increase the impact of credential compromise.
-
-When a workload needs to access multiple resources or federate to multiple
-Identity Providers, it SHOULD obtain separate credentials for each intended
-resource or Identity Provider, where supported by the workload platform.
+As long as the workload platform supports issuance of multiple credentials, a workload
+SHOULD obtain a distinct credential for each resource or Identity
+Provider it interacts with. In particular, the credential used to federate to an Identity
+Provider SHOULD NOT be used for direct platform access; reusing a credential across these
+contexts conflates trust boundaries and increases the impact of a compromise
+(see {{audience}}).
 
 ### Environment Variables
 

--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -166,23 +166,18 @@ The figure outlines the following steps which are applicable in any pattern.
      to the workload or pulled by the workload. A workload may obtain
      multiple credentials from the platform, each with its own audience and
      lifetime, tailored to the specific resource or Identity Provider it
-     needs to interact with. Credentials SHOULD have as small a set of audiences
-     as possible to limit the scope of any single credential. See {{audience}}
+     needs to interact with. See {{general-requirements}} and {{audience}}
      for more details and security implications.
 
 * A) The credential can give the workload direct access to resources within the
      platform or the platform itself, for example to perform infrastructure
-     operations. The credential used for this step SHOULD be scoped specifically
-     to the platform resource being accessed.
+     operations.
 
 * B1) The workload uses a credential to federate to an Identity Provider. This
       step is optional and only needed when accessing outside resources. The
-      credential used for federation SHOULD carry the Identity Provider as its
-      sole audience and SHOULD NOT be the same credential used for platform
-      access in step A). The Identity Provider validates the platform-issued
-      credential, and in return, issues a new credential, such as an OAuth 2.0
-      access token, that the workload can use to access resources in the
-      Identity Provider's domain.
+      Identity Provider validates the platform-issued credential, and in return,
+      issues a new credential, such as an OAuth 2.0 access token, that the
+      workload can use to access resources in the Identity Provider's domain.
 
 * B2) Using the credential obtained at step B1, the workload accesses resources
       outside of the platform.
@@ -712,6 +707,26 @@ In above pattern each workload has a specific sidecar. An alternative deployment
 All security considerations in section 8 of {{!OAUTH-ASSERTION=RFC7521}} apply.
 
 ## Credential Delivery {#security-credential-delivery}
+
+### General Credentials Requirements {#general-requirements}
+
+Workload platforms and Identity Providers SHOULD issue credentials with as
+small a set of audiences as possible to limit the scope of any single
+credential. For JWT-based credentials, more specific requirements and security
+considerations for the `aud` claim are described in {{audience}}.
+
+Credentials used for direct access to platform resources SHOULD be scoped
+specifically to the platform resource being accessed.
+
+Credentials used to federate to an Identity Provider SHOULD carry that Identity
+Provider as their sole audience. A credential used for federation SHOULD NOT be
+the same credential used for direct platform access. Reusing a credential across
+platform access and federation contexts can conflate trust boundaries and
+increase the impact of credential compromise.
+
+When a workload needs to access multiple resources or federate to multiple
+Identity Providers, it SHOULD obtain separate credentials for each intended
+resource or Identity Provider, where supported by the workload platform.
 
 ### Environment Variables
 


### PR DESCRIPTION
To address an issue raised by @jricher:

> It's a little weird having normative requirements in the introduction. Many readers will gloss pass this section and miss this. Suggest moving normative requirements lower, perhaps a "general requirements" section in 3 instead?

I think this belongs to security considerations rather than section 3...