### PR TITLE
Discourage environment credentials

### DIFF
--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -213,6 +213,11 @@ mechanisms, e.g., through the `env` command in Linux. Note that environment
 variables are static in nature in that they cannot be changed after application
 initialization.
 
+This delivery pattern is generally discouraged for production workload identity
+credentials, because environment variables are frequently exposed through
+debugging, logging, process inspection, and observability tooling. Security
+considerations for this pattern are discussed in {{security-credential-delivery-env}}.
+
 ## Filesystem
 
 Filesystem delivery allows both container secret injection and access control.
@@ -713,7 +718,7 @@ All security considerations in section 8 of {{!OAUTH-ASSERTION=RFC7521}} apply.
 
 ## Credential Delivery {#security-credential-delivery}
 
-### Environment Variables
+### Environment Variables {#security-credential-delivery-env}
 
 Leveraging environment variables to provide credentials presents many security
 limitations. Environment variables have a wide set of use cases and are observed


### PR DESCRIPTION
To address an issue raised by @jricher:

> Env vars aren't recommended in most practices, or at least frowned on, so maybe call that out here in a non-normative way, and forward point to §5.1.1.