### PR TITLE
Clarify workload credential attestation semantics

### DIFF
--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -113,6 +113,15 @@ platforms provision workloads with a credential, such as a JWT
 {{!JWT=RFC7519}}. Cryptographically signed by the platform's issuer,
 this credential attests the workload and its attributes.
 
+A platform-issued workload credential can represent the result of
+platform-side validation, but it is not necessarily fresh RATS Evidence or an
+Attestation Result as defined in {{?RATS=RFC9334}} unless the platform
+explicitly defines it that way. A relying party that needs current workload
+state, platform posture, or key-protection properties should not infer those
+properties only from possession of a credential. It should instead rely on the
+credential lifetime, audience, proof-of-possession, invalidation or status
+checks, or an explicit attestation mechanism appropriate to the deployment.
+
 {{fig-overview}} illustrates a generic pattern that is seen across many workload
 platforms, more concrete variations are found in {{practices}}.
 


### PR DESCRIPTION
## Summary

This PR adds a short clarification in the Introduction that a platform-issued workload credential can represent platform-side validation, but is not necessarily fresh RATS Evidence or an Attestation Result unless the platform defines it that way.

It also points relying parties that need current workload state, platform posture, or key-protection properties toward credential lifetime, audience, proof-of-possession, invalidation/status checks, or an explicit attestation mechanism.

Fixes #88.

## Validation

- `env -u HTTPS_PROXY -u HTTP_PROXY -u ALL_PROXY -u https_proxy -u http_proxy -u all_proxy make`
- `git diff --check`
- `idnits draft-ietf-wimse-workload-identity-practices.txt` was run after generating the editor copy; it reports existing editor-copy filename/docname/page-format nits unrelated to this text change.