### PR TITLE
AD feedback

### DIFF
--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -876,9 +876,9 @@ expressed without requiring deep knowledge of vendor-specific claim structures.
 
 ## Token lifetime
 
-Tokens SHOULD NOT exceed the lifetime of the workloads instance they represent. 
-For example, a token valid for two hours or more exceeds the lifetime of a 
-workload that is expected to run for one hour. A token that outlives its workload 
+Tokens SHOULD NOT exceed the lifetime of the workloads instance they represent.
+For example, a token valid for two hours or more exceeds the lifetime of a
+workload that is expected to run for one hour. A token that outlives its workload
 may continue to be accepted by relying parties even after the workload (and its
 associated authorization context) has ceased to exist, enabling unauthorized
 access if the token is compromised.
@@ -898,7 +898,7 @@ example, replicas or parallel tasks), this applies to each instance
 individually. Without this capability, credentials for terminated instances
 remain usable until their natural expiry, creating a window for unauthorized
 use. Without a status query mechanism, relying parties have no way to detect
-that an instance has been removed. How these credentials are invalidated and 
+that an instance has been removed. How these credentials are invalidated and
 the status is queried varies and is not in scope of this document.
 
 ## Proof of possession {#proof-of-possession}

--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -624,8 +624,8 @@ or misuse if the token is exfiltrated.
 The same bearer credential MUST NOT be used across different trust domains
 without appropriate controls. While direct use of the issued credential
 within the same cloud security boundary is common, reusing that credential outside of
-its intended scope can increase the risk of credential leakage and allows for 
-impersonation. The federation step via the Secure Token Service (Step B1) serves as 
+its intended scope can increase the risk of credential leakage and enable
+impersonation. The federation step via the Secure Token Service (Step B1) serves as
 a boundary, allowing the original credential to be exchanged for a new credential 
 that is scoped, audience-restricted, and appropriate for the target resource.
 
@@ -773,10 +773,11 @@ confidentiality or integrity protection. Privileged components on a host or in
 the infrastructure may be able to eavesdrop on a connection and view a
 credential within it.
 
-Mitigations are required for a particular variant of Server-Side Request Forgery
-(SSRF) attacks against Local APIs. For example, requiring a specific header that
-cannot be controlled externally or preventing the use of link-local IPs,
-including through redirects. See {{application-interaction-with-credential-sources}} for details.
+Mitigations are required for Server-Side Request Forgery (SSRF) attacks against
+Local APIs. For example, implementations can require a specific header that
+cannot be controlled externally or prevent untrusted input from triggering
+requests to link-local IPs, including through redirects. See
+{{application-interaction-with-credential-sources}} for details.
 
 Adequate assurance that the identity represents the workload is required to make
 sure unauthorized access is denied and credentials are not issued to other
@@ -806,8 +807,8 @@ by other processes running on the same host, making them an unreliable transport
 for credentials in environments where process isolation is not strictly enforced.
 
 For these reasons, environment variables MUST NOT be used to deliver workload
-identity credentials in production deployments, except where the platform offers
-no other delivery pattern.
+identity credentials in production deployments where the platform offers another
+delivery pattern.
 
 ### Application Interaction with Credential Sources {#application-interaction-with-credential-sources}
 

--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -626,7 +626,7 @@ without appropriate controls. While direct use of the issued credential
 within the same cloud security boundary is common, reusing that credential outside of
 its intended scope can increase the risk of credential leakage and enable
 impersonation. The federation step via the Secure Token Service (Step B1) serves as
-a boundary, allowing the original credential to be exchanged for a new credential 
+a boundary, allowing the original credential to be exchanged for a new credential
 that is scoped, audience-restricted, and appropriate for the target resource.
 
 ## Continuous Integration and Deployment Systems {#cicd}

--- a/draft-ietf-wimse-workload-identity-practices.md
+++ b/draft-ietf-wimse-workload-identity-practices.md
@@ -101,7 +101,7 @@ turn, issue credentials that grant access to resources.
 Traditionally, workloads were provisioned with static client credentials (e.g.,
 passwords, API keys) and used the corresponding flow as described in {{Section 1.3.4 of OAUTH-FRAMEWORK}}
 to retrieve an OAuth 2.0 access token. This model presents a number of security
-and maintenance issues. Secrets must be provisioned and rotated, which requires
+and maintenance issues. Secrets need to be provisioned and rotated, which requires
 either automation to be built, or periodic manual effort. Secrets may be stolen
 and used by attackers to impersonate the workload. Flows outside of the
 OAuth 2.0 framework (such as direct API keys or HTTP basic authentication)
@@ -187,20 +187,7 @@ section highlights the pros and cons of common solutions. Security
 recommendations for these methods are covered in
 {{security-credential-delivery}}.
 
-## Environment Variables
-
-Injecting the credentials into the environment variables allows for simple and
-fast deployments. Applications can directly access them through system-level
-mechanisms, e.g., through the `env` command in Linux. Note that environment
-variables are static in nature in that they cannot be changed after application
-initialization.
-
-This delivery pattern is generally discouraged for production workload identity
-credentials, because environment variables are frequently exposed through
-debugging, logging, process inspection, and observability tooling. Security
-considerations for this pattern are discussed in {{security-credential-delivery-env}}.
-
-## Filesystem
+## Filesystem {#filesystem}
 
 Filesystem delivery allows both container secret injection and access control.
 Many solutions find the main benefit in the asynchronous provisioning of the
@@ -220,10 +207,10 @@ writing to a temporary file and renaming it atomically). Solutions SHOULD also
 perform a flush operation immediately after the update to minimize the chance
 of race conditions and ensure durability.
 
-## Local APIs
+## Local APIs {#local-apis}
 
 In this pattern, the workload obtains credentials by communicating with a
-local API exposed by the credential issuer. Implementations commonly use UNIX
+Local API exposed by the credential issuer. Implementations commonly use UNIX
 domain sockets (e.g., SPIFFE), loopback interfaces, or link-local "magic addresses"
 169.254.169.254 commonly used for cloud provider Instance Metadata Services as
 the transport mechanism.
@@ -234,10 +221,26 @@ This enables the use of short-lived, narrowly scoped credentials, improving
 security posture compared to long-lived secrets.
 
 The security of this approach relies heavily on network isolation to prevent
-unauthorised access to the local API. In addition, the pattern requires client-side
+unauthorized access to the Local API. In addition, the pattern requires client-side
 code that is specific to the exposed API, which may introduce portability challenges
-across platforms and providers. Further security considerations for local APIs are
+across platforms and providers. Further security considerations for Local APIs are
 discussed in {{local-api-security}}.
+
+## Environment Variables {#env-vars}
+
+Injecting the credentials into the environment variables allows for simple and
+fast deployments. Applications can directly access them through system-level
+mechanisms, e.g., through the `env` command in Linux. Note that environment
+variables are static in nature in that they cannot be changed after application
+initialization.
+
+While environment variables are a common delivery pattern, they are highly
+susceptible to leakage through logging, process inspection, error reporting, and
+other means. Filesystem delivery ({{filesystem}}) or Local APIs
+({{local-apis}}) are therefore preferred, and environment variables MUST NOT be used for such credentials
+where the platform offers one of these alternatives. Some platforms offer no
+other delivery pattern; that case, along with the underlying security
+considerations, is discussed in {{security-credential-delivery-env}}.
 
 # Practices {#practices}
 
@@ -296,8 +299,9 @@ To validate service account tokens, Kubernetes allows workloads to:
   calling the Token Review API.
 
 * Optionally, a JSON Web Key Set {{!JWK=RFC7517}} is exposed via a web server. This
-  allows the Service Account Token to be validated outside of the cluster and
-  access to the actual Kubernetes Control Plane API.
+  allows external systems to validate Service Account Tokens independently,
+  without requiring direct network access to, or credentials for, the Kubernetes
+  Control Plane API.
 
 ~~~aasvg
          +-------------------------------------------------+
@@ -415,10 +419,11 @@ credentials in one of two forms:
 * X509-SVID, a X.509 certificate containing the workload's SPIFFE ID in the Subject
   Alternative Name (SAN) URI field, along with the corresponding key pair.
 
-* JWT-SVID, a signed JWT containing the workload's SPIFFE ID in the `sub` claim.
-  The Workload API does not require clients to authenticate themselves.
+* JWT-SVID, a signed JWT containing the workload's SPIFFE ID in the `"sub"`
+  claim.
 
-Instead, the API implementation identifies workloads by collecting contextual
+The Workload API does not require clients to authenticate themselves. Instead,
+the API implementation identifies workloads by collecting contextual
 information from the environment, such as process attributes, kernel metadata,
 or orchestrator-provided labels. This out-of-band identification allows
 workloads to obtain their identity credentials without needing a pre-existing
@@ -433,8 +438,8 @@ target; see {{audience}} for details.
 For validation, SPIFFE defines a "trust bundle" per trust domain. A trust
 bundle is a set of public keys encoded in JWK format {{JWK}} that can be
 used to validate credentials. For JWT-SVIDs, the bundle contains signing keys
-identified by a `use` value of `jwt-svid`. For X509-SVIDs, the bundle contains
-CA certificates identified by a `use` value of `x509-svid`. Trust bundle
+identified by a `"use"` value of `jwt-svid`. For X509-SVIDs, the bundle contains
+CA certificates identified by a `"use"` value of `x509-svid`. Trust bundle
 contents can be retrieved from the Workload API or from a dedicated SPIFFE
 Bundle Endpoint (see {{SPIFFE}}).
 
@@ -616,13 +621,13 @@ by constraining token scope, lifetime, or audience, or by requiring additional
 proof-of-possession mechanisms. These mechanisms reduce the risk of token replay
 or misuse if the token is exfiltrated.
 
-Care must be taken to avoid using the same bearer credential across different
-trust domains without appropriate controls. While direct use of the issued credential
+The same bearer credential MUST NOT be used across different trust domains
+without appropriate controls. While direct use of the issued credential
 within the same cloud security boundary is common, reusing that credential outside of
-its intended scope can increase the risk of credential leakage. The federation step
-via the Secure Token Service (Step B1) serves as a boundary, allowing the original
-credential to be exchanged for a new credential that is scoped, audience-restricted,
-and appropriate for the target resource.
+its intended scope can increase the risk of credential leakage and allows for 
+impersonation. The federation step via the Secure Token Service (Step B1) serves as 
+a boundary, allowing the original credential to be exchanged for a new credential 
+that is scoped, audience-restricted, and appropriate for the target resource.
 
 ## Continuous Integration and Deployment Systems {#cicd}
 
@@ -739,7 +744,7 @@ Credentials SHOULD be scoped as narrowly as possible: each SHOULD carry the
 smallest set of audiences that lets it serve its purpose. A credential for direct access
 to a platform resource SHOULD be scoped to that resource; a credential used to
 federate to an Identity Provider SHOULD carry that Identity Provider as its sole audience.
-See {{audience}} for the rationale and for specific requirements on the `aud` claim of
+See {{audience}} for the rationale and for specific requirements on the `"aud"` claim of
 JWT-based credentials.
 
 As long as the workload platform supports issuance of multiple credentials, a workload
@@ -749,40 +754,27 @@ Provider SHOULD NOT be used for direct platform access; reusing a credential acr
 contexts conflates trust boundaries and increases the impact of a compromise
 (see {{audience}}).
 
-### Environment Variables {#security-credential-delivery-env}
+### Filesystem {#security-credential-delivery-filesystem}
 
-Leveraging environment variables to provide credentials presents many security
-limitations. Environment variables have a wide set of use cases and are observed
-by many components. They are often captured for monitoring, observability,
-debugging and logging purposes and sent to components outside of the workload.
-Access control is not trivial and does not achieve the same security results as
-other methods. Additionally, environment variables may be spoofed or altered
-by other processes running on the same host, making them an unreliable transport
-for credentials in environments where process isolation is not strictly enforced.
+Access control to the mounted file SHOULD be configured to limit reads to
+authorized applications. Linux supports solutions such as DAC (uid and gid) or
+MAC (e.g., SELinux, AppArmor).
 
-This approach should be limited to non-production cases where convenience
-outweighs security considerations, and the provided secrets are limited in
-validity or utility. For example, an initial secret might be used during the
-setup of the application.
-
-### Filesystem
-
-* 1) Access control to the mounted file should be configured to limit reads to
-     authorized applications. Linux supports solutions such as DAC (uid and
-     gid) or MAC (e.g., SELinux, AppArmor).
-
-* 2) Mounted shared memory should be isolated from other host OS paths and
-     processes. For example, on Linux this can be achieved by using namespaces.
+Credentials written to durable storage persist until they are overwritten or
+removed, and may be captured in backups, snapshots, or images. Implementations
+therefore commonly mount credentials from memory-backed storage instead. Such a
+mount SHOULD be isolated from other host OS paths and processes. For example, on
+Linux this can be achieved by using namespaces.
 
 ### Local APIs {#local-api-security}
 
-Local APIs often operate in clear-text such as unencrypted HTTP without any
-confidentiality or integrity protection. Privileged component on the machine or
-in the infrastructure can be able to eavesdrop on the connection and the credential
-within it.
+Local APIs often operate in clear-text, such as unencrypted HTTP, without any
+confidentiality or integrity protection. Privileged components on a host or in
+the infrastructure may be able to eavesdrop on a connection and view a
+credential within it.
 
-Mitigating measures are required to mitigate a particular variant of Server-Side Request Forgery attacks
-against local APIs. For example, requiring a specific header that
+Mitigations are required for a particular variant of Server-Side Request Forgery
+(SSRF) attacks against Local APIs. For example, requiring a specific header that
 cannot be controlled externally or preventing the use of link-local IPs,
 including through redirects. See {{application-interaction-with-credential-sources}} for details.
 
@@ -797,10 +789,25 @@ IP or other machine-global identifiers permits any process to receive the
 identity, while including user ID or other process-scoped identifiers prevents
 this broader access.
 
-The potential for denial-of-service attacks against Local APIs need to be taken
-into account and protective measures should be implemented. Depending on the platform
+The potential for denial-of-service attacks against Local APIs needs to be taken
+into account and protective measures SHOULD be implemented. Depending on the platform
 these attacks can affect other workloads and their ability to receive a platform
 credential.
+
+### Environment Variables {#security-credential-delivery-env}
+
+Leveraging environment variables to provide credentials presents many security
+limitations. Environment variables have a wide set of use cases and are observed
+by many components. They are often captured for monitoring, observability,
+debugging and logging purposes and sent to components outside of the workload.
+Access control is not trivial and does not achieve the same security results as
+other methods. Additionally, environment variables may be spoofed or altered
+by other processes running on the same host, making them an unreliable transport
+for credentials in environments where process isolation is not strictly enforced.
+
+For these reasons, environment variables MUST NOT be used to deliver workload
+identity credentials in production deployments, except where the platform offers
+no other delivery pattern.
 
 ### Application Interaction with Credential Sources {#application-interaction-with-credential-sources}
 
@@ -810,32 +817,32 @@ itself to retrieve credentials rather than accessing the credential service dire
 
 For example, untrusted input may be used to manipulate file paths when credentials are mounted
 on a filesystem, or to trigger requests to local credential endpoints such as metadata or
-workload APIs (for example via server-side request forgery). Similarly, command execution or
+workload APIs (for example via SSRF). Similarly, command execution or
 unintended outbound requests may result in bearer tokens or proof-of-possession key material
 being disclosed.
 
 Workloads therefore MUST treat credential locations as sensitive security boundaries.
 Untrusted input MUST NOT influence how credential files are accessed or how local credential
-APIs are contacted. Implementations SHOULD minimise which components can access credentials
+APIs are contacted. Implementations SHOULD minimize which components can access credentials
 and prefer proof-of-possession credentials over bearer tokens where supported. Failure to
-minimise credential access increases the attack surface by allowing more code paths to
+minimize credential access increases the attack surface by allowing more code paths to
 interact with sensitive material. Failing to use proof-of-possession credentials where
 available means that stolen bearer tokens can be replayed by an attacker from any location.
 
 These risks exist even when credential services are reachable only locally, since compromise
-often occurs through application behaviour rather than network access to the credential provider.
+often occurs through application behavior rather than network access to the credential provider.
 
 ## Token typing
 
-Issuers SHOULD strongly type the issued tokens to workloads via the JOSE `typ`
-header and Identity Providers accepting these tokens SHOULD validate the
-value of it according to policy. See {{Section 3.1 of !JWT-BCP=RFC8725}} for details
-on explicit typing. Without explicit typing, a token intended for one purpose
+Issuers SHOULD strongly type the issued tokens to workloads via the JOSE `"typ"`
+header parameter ({{Section 4.1.9 of !JWS=RFC7515}}), and Identity Providers
+accepting these tokens SHOULD validate its value according to policy. See
+{{Section 3.1 of !JWT-BCP=RFC8725}} for details on explicit typing. Without explicit typing, a token intended for one purpose
 (e.g., a refresh token or an identity assertion) may be accepted in a context
 where a different token type is expected, enabling cross-protocol or
 cross-context token confusion attacks.
 
-Issuers SHOULD use `authorization-grant+jwt` as a `typ` value according to
+Issuers SHOULD use `authorization-grant+jwt` as a `"typ"` value according to
 {{!OAUTH-JWT=I-D.ietf-oauth-rfc7523bis}}. For broad support, `JWT` or `JOSE` MAY be used by
 issuers and accepted by authorization servers but it is important to highlight
 that a wide range of tokens, meant for all sorts of purposes, use these values
@@ -847,8 +854,9 @@ mitigate confusion.
 
 ## Custom claims are important for context
 
-Some platform-issued credentials have custom claims that are vital for context
-and are required to be validated. For example, in a continuous integration and
+Some platform-issued credentials carry custom claims that are vital for context.
+Relying parties need to consider the values of these claims, not merely check
+that they are present. For example, in a continuous integration and
 deployment platform where a workload is scheduled for a Git repository, the
 branch is crucial. A "main" branch may be protected and considered trusted to
 federate to external authorization servers. But other branches may not be
@@ -858,21 +866,21 @@ Authorization servers that validate assertions SHOULD make use of these claims.
 Ignoring custom claims may result in overly permissive authorization decisions,
 such as granting a credential issued for an untrusted branch the same access as
 one issued for a protected branch. Platform issuers SHOULD allow differentiation
-based on the subject claim alone, so that authorization policies can be
+based on the `"sub"` (subject) claim alone, so that authorization policies can be
 expressed without requiring deep knowledge of vendor-specific claim structures.
 
 ## Token lifetime
 
 Tokens SHOULD NOT exceed the lifetime of the workloads they represent. For
-example, a workload that has an expected lifetime of one hour should not receive
-a token valid for two hours or more. A token that outlives its workload may
+example, a token valid for two hours or more exceeds the lifetime of a workload
+that is expected to run for one hour. A token that outlives its workload may
 continue to be accepted by relying parties even after the workload (and its
 associated authorization context) has ceased to exist, enabling unauthorized
 access if the token is compromised.
 
 Within the scope of this document, where a platform-issued credential is used
 to authenticate to retrieve an access token for an external authorization
-domain, short-lived credentials are recommended. Short-lived credentials
+domain, short-lived credentials are RECOMMENDED. Short-lived credentials
 reduce the window during which a stolen credential can be exploited and
 limit the need for explicit revocation infrastructure.
 
@@ -883,9 +891,8 @@ ceases to exist and SHOULD offer validators a mechanism to query this status.
 Without invalidation, tokens for terminated workloads remain usable until their
 natural expiry, creating a window for unauthorized use. Without a status query
 mechanism, relying parties have no way to detect that a workload has been
-removed and must accept the token as is. How these credentials are
-invalidated and the status is queried varies and is not in scope of this
-document.
+removed. How these credentials are invalidated and the status is queried varies
+and is not in scope of this document.
 
 ## Proof of possession {#proof-of-possession}
 
@@ -906,8 +913,8 @@ of the external authorization domains.
 ## Audience {#audience}
 
 For issued credentials in the form of JWTs, they MUST be audienced using the
-`aud` claim. Each JWT SHOULD only carry a single audience. Using multiple
-audiences in a single token means that any relying party listed in the `aud`
+`"aud"` claim. Each JWT SHOULD only carry a single audience. Using multiple
+audiences in a single token means that any relying party listed in the `"aud"`
 claim can present that token to any other party listed in the same claim,
 potentially gaining unintended access. A single-audience token limits the blast
 radius if the token is compromised or misused. We RECOMMEND using
@@ -917,7 +924,7 @@ security implications.
 Some workload platforms provide credentials for interacting with their own APIs
 (e.g., Kubernetes). These credentials MUST NOT be used beyond the platform API.
 In the example of Kubernetes, a token used for anything other than the Kubernetes
-API itself MUST NOT carry the Kubernetes server in the `aud` claim. Reusing a
+API itself MUST NOT carry the Kubernetes server in the `"aud"` claim. Reusing a
 platform API token for federation or resource access outside the platform
 conflates trust boundaries: the token's audience includes the platform, so any
 relying party that accepts it could impersonate the workload back to the
@@ -928,7 +935,7 @@ platform.
 In multi-tenant platforms, relying parties MUST carefully evaluate which attributes
 are considered trustworthy when making authorization decisions. Access or federation
 MUST NOT be granted based solely on untrusted or easily forgeable attributes.
-In particular, the `issuer` claim in such environments may not uniquely identify
+In particular, the `"iss"` (issuer) claim in such environments may not uniquely identify
 a trusted authority, since each tenant could be configured with the same issuer
 identifier.
 
@@ -958,11 +965,22 @@ In this case, technically, the protected resource and workload are part of the s
 
 ## Custom assertion flows
 
-While {{OAUTH-ASSERTION}} and {{OAUTH-JWT}} are the proposed standards for this pattern, some authorization servers use {{!OAUTH-TOKENEXCHANGE=RFC8693}} or a custom API for the issuance of an access token based on existing platform identity credentials. These patterns are not recommended and prevent interoperability.
+While {{OAUTH-ASSERTION}} and {{OAUTH-JWT}} are the proposed standards for this pattern, some authorization servers use {{!OAUTH-TOKENEXCHANGE=RFC8693}} or a custom API for the issuance of an access token based on existing platform identity credentials. These patterns are discouraged as they prevent interoperability.
 
 # Document History
 
    [[ To be removed from the final specification ]]
+
+   -06
+
+   * Address AD evaluation comments from Charles Eckel
+   * Review use of BCP 14 language for consistency
+   * Reformat the filesystem security considerations and cover
+     credentials on durable storage
+   * Reference RFC 7515 for the JOSE "typ" header parameter
+   * Clarify Kubernetes JWK Set validation, SPIFFE Workload API client
+     authentication, custom claim validation and workload invalidation
+   * Editorial improvements
 
    -04
 


### PR DESCRIPTION
PR for AD feedback received on the mailing list.

<details>

<summary>Feedback in detail</summary>

# Charles Eckel, ART AD, AD evaluation: draft-ietf-wimse-workload-identity-practices-05 
CC @eckelcu

* line numbers:
  - [https://author-tools.ietf.org/api/idnits?url=https://www.ietf.org/archive/id/draft-ietf-wimse-workload-identity-practices-05.txt&submitcheck=True](https://author-tools.ietf.org/api/idnits?url=https%3A%2F%2Fwww.ietf.org%2Farchive%2Fid%2Fdraft-ietf-wimse-workload-identity-practices-05.txt&submitcheck=True)

* comment syntax:
  - https://github.com/mnot/ietf-comments/blob/main/format.md


Thanks to the authors and the working group for producing this document. It provides an informative survey of current industry practices for workload identity and successfully documents existing practices without attempting to redefine them. Thanks as well to Justin Richer, the document shepherd, for his helpful write-up.

## Comments

### General comment on use of normative language

This document is informational yet makes extensive use of normative language, not only in the security considerations section, but elsewhere as well. This is generally okay; however, BCP14 language (capitalized normative language) is primarily for interoperability, and any "SHOULD" or "SHOULD NOT" statements are likely to draw additional scrutiny as to why they are "SHOULD" instead of "MUST" (i.e., in what cases is it okay to not adhere to the SHOULD).  Using lowercase must/should is still normative, but is not held to the same bar as when capitalized, as clarified in the [IESG Statement on Clarifying the Use of BCP 14 Key [Words](https://datatracker.ietf.org/doc/statement-iesg-statement-on-clarifying-the-use-of-bcp-14-key-words/)](http://words](https//datatracker.ietf.org/doc/statement-iesg-statement-on-clarifying-the-use-of-bcp-14-key-words/)).

It is also important that any use of normative language is done so consistently. 

```
660	   Care must be taken to avoid using the same bearer credential across
661	   different trust domains without appropriate controls.  While direct
```

For consistency with the rest of the section 5, consider s/must/MUST or s/MUST/must elsewhere in section 5. I recommend reviewing all other instances of 'must' and 'should' for consistency. For example, there are several occurrences within Section 5.1 that should be revisited.

### Section 3.1, Environment Variables

```
207	3.1.  Environment Variables

209	   Injecting the credentials into the environment variables allows for
210	   simple and fast deployments.  Applications can directly access them
211	   through system-level mechanisms, e.g., through the env command in
212	   Linux.  Note that environment variables are static in nature in that
213	   they cannot be changed after application initialization.

215	   This delivery pattern is generally discouraged for production
216	   workload identity credentials, because environment variables are
217	   frequently exposed through debugging, logging, process inspection,
218	   and observability tooling.  Security considerations for this pattern
219	   are discussed in Section 5.1.2.
```

Though common practice, use of environment variables in this context needs to be strongly discouraged. The text in this section does mention this is generally discouraged, and section 5.1.2 describes why, but I believe it would be helpful to state this more strongly here by adding something like the following:

``` 
While environment variables are a common delivery pattern, they are highly susceptible to leakage through logging, process inspection, error reporting, and other means. Developers SHOULD prefer filesystem-based mechanisms (Section 3.2) or Local APIs (Section 3.3) where possible.
```

It might be worth considering reordering the sections as well, moving 3.1 Environment Variables to the end.

### Section 4.1, JWK

I do not understand the second part of the second sentence of the following bullet:

```
326	   *  Optionally, a JSON Web Key Set [JWK] is exposed via a web server.
327	      This allows the Service Account Token to be validated outside of
328	      the cluster and access to the actual Kubernetes Control Plane API.
```

Based on what I think it is intended to convey, perhaps it can be reworded as follows:

```
Optionally, a JSON Web Key Set [JWK] is exposed via a web server. This allows external systems to validate Service Account Tokens independently, without requiring direct network access or credentials for the Kubernetes Control Plane API.
```

### Section 4.2, SPIFFE Workload API

```
443	   *  X509-SVID, a X.509 certificate containing the workload's SPIFFE ID
444	      in the Subject Alternative Name (SAN) URI field, along with the
445	      corresponding key pair.

447	   *  JWT-SVID, a signed JWT containing the workload's SPIFFE ID in the
448	      sub claim.  The Workload API does not require clients to
449	      authenticate themselves.

451	   Instead, the API implementation identifies workloads by collecting
452	   contextual information from the environment, such as process
453	   attributes, kernel metadata, or orchestrator-provided labels.  This
```

I believe the following text in the second bullet should be relocated to the start of the paragraph after the second bullet, as follows:

```
*  X509-SVID, a X.509 certificate containing the workload's SPIFFE ID in the Subject Alternative Name (SAN) URI field, along with the corresponding key pair.

*  JWT-SVID, a signed JWT containing the workload's SPIFFE ID in the sub claim.

The Workload API does not require clients to authenticate themselves. Instead, the API implementation identifies workloads by collecting contextual information from the environment, such as process attributes, kernel metadata, or orchestrator-provided labels.  This
```

### Section 5.1.2 Warn more strongly against inappropriate use of env vars 

```
818	   This approach should be limited to non-production cases where
819	   convenience outweighs security considerations, and the provided
820	   secrets are limited in validity or utility.  For example, an initial
821	   secret might be used during the setup of the application.
```

I am not sure if it was intended, but I believe normative language is more appropriate here.

```
This approach SHOULD NOT be used except for non-production cases ...
````

Even this will likely draw scrutiny from our security friends.
Did the working group discuss making this a "MUST NOT" except ...?

### Section 5.2, JOSE typ header

```
895	   Issuers SHOULD strongly type the issued tokens to workloads via the
896	   JOSE typ header and Identity Providers accepting these tokens SHOULD
897	   validate the value of it according to policy.  See Section 3.1 of
898	   [JWT-BCP] for details on explicit typing.  Without explicit typing, a
```

In addition to the reference to [JWT-BCP], it would be helpful to add a reference to RFC 7515, which defines the ``typ`` header parameter. Also, it might be helpful to quote ``typ`` and to expand "typ header" to "``typ`` header parameter."

### Section 5.3, clarify what needs to be validated

```
917	   Some platform-issued credentials have custom claims that are vital
918	   for context and are required to be validated.  For example, in a
```

From the text, it is not clear whether the claims need to be validated, or the claims need to be present for the credential to be validated.

### Section 5.5, handling error case

```
956	   for unauthorized use.  Without a status query mechanism, relying
957	   parties have no way to detect that a workload has been removed and
958	   must accept the token as is.  How these credentials are invalidated
```

"must accept" seems inappropriate and potentially ill-advised in this case. I suggest removing it and leaving the error handling out of scope if no better alternative exists.

## Nits

### Reformat bullets as paragraphs

```
823	5.1.3.  Filesystem

825	   *  1) Access control to the mounted file should be configured to
826	      limit reads to authorized applications.  Linux supports solutions
827	      such as DAC (uid and gid) or MAC (e.g., SELinux, AppArmor).

829	   *  2) Mounted shared memory should be isolated from other host OS
830	      paths and processes.  For example, on Linux this can be achieved
831	      by using namespaces.
```

Something went wrong here. You can simply reformat the bullets as paragraphs, but perhaps some other text was lost and needs to be added back?

### Reword sentence

The second sentence below does not read well.

```
835	   Local APIs often operate in clear-text such as unencrypted HTTP
836	   without any confidentiality or integrity protection.  Privileged
837	   component on the machine or in the infrastructure can be able to
838	   eavesdrop on the connection and the credential within it.
```

I suggest rewording as follows:

```
Local APIs often operate in clear-text, such as unencrypted HTTP, without any confidentiality or integrity protection. Privileged components on a host or in the infrastructure may be able to eavesdrop on a connection and view a credential within it.
```

### Local APIs, consistent caps

```
841	   Server-Side Request Forgery attacks against local APIs.  For example,
```

s/local/Local

### Expand SSRF

```
966	   mitigates token theft.  Without proof of possession, a bearer token
967	   intercepted in transit (e.g., via a compromised log, a man-in-the-
968	   middle, or SSRF) can be replayed by any party, from any location, for
969	   the remaining lifetime of the token.  For X.509-based credentials,
```

Expand SSRF, or consider replacing it with its expanded form as this appears to be the only place it is used.

### quote "aud" in aud claim

```
983	   using the aud claim.  Each JWT SHOULD only carry a single audience.
```

s/aud/``aud``

Note, there are several occurrences of "aud" in this section.

### issuer claim

```
1007	   untrusted or easily forgeable attributes.  In particular, the issuer
1008	   claim in such environments may not uniquely identify a trusted
```

For consistency and clarity, quote "issuer".

s/issuer/``issuer``
—

</details>
